### PR TITLE
Allow empty DISCRIMINATED-UNION-OPTIONS 

### DIFF
--- a/src/back/template_instantiator_derived.cpp
+++ b/src/back/template_instantiator_derived.cpp
@@ -710,21 +710,19 @@ void DiscriminatedUnionExpressionObject::execBuiltinFunction( Stack& stack, Pred
 							}
 					}
 				}
-				if ( usedMembers.size() )
-				{
-					StackElement el;
-					el.argtype = ARGTYPE::OBJPTR;
-					string enumValName = itv.first;
-					auto& idlEnumVal = enumMember->type.idlRepresentation->enumValues.find( enumValName );
-					assert( idlEnumVal != enumMember->type.idlRepresentation->enumValues.end() );
-					auto& mappingEnumVal = enumMember->type.mappingRepresentation->enumValues.find( enumValName );
-					assert( mappingEnumVal != enumMember->type.mappingRepresentation->enumValues.end() );
-					auto& encodingEnumVal = enumMember->type.encodingRepresentation->enumValues.find( enumValName );
-					assert( encodingEnumVal != enumMember->type.encodingRepresentation->enumValues.end() );
-					DiscriminatedUnionOptionExpressionObject* duoti = new DiscriminatedUnionOptionExpressionObject( *enumMember, usedMembers, enumValName, idlEnumVal->second, mappingEnumVal->second, encodingEnumVal->second, templateSpace, outstr );
-					el.singleObject.reset( duoti );
-					elem.anyList.push_back( std::move( el ) );
-				}
+
+                StackElement el;
+				el.argtype = ARGTYPE::OBJPTR;
+				string enumValName = itv.first;
+				auto& idlEnumVal = enumMember->type.idlRepresentation->enumValues.find( enumValName );
+				assert( idlEnumVal != enumMember->type.idlRepresentation->enumValues.end() );
+				auto& mappingEnumVal = enumMember->type.mappingRepresentation->enumValues.find( enumValName );
+				assert( mappingEnumVal != enumMember->type.mappingRepresentation->enumValues.end() );
+				auto& encodingEnumVal = enumMember->type.encodingRepresentation->enumValues.find( enumValName );
+				assert( encodingEnumVal != enumMember->type.encodingRepresentation->enumValues.end() );
+				DiscriminatedUnionOptionExpressionObject* duoti = new DiscriminatedUnionOptionExpressionObject( *enumMember, usedMembers, enumValName, idlEnumVal->second, mappingEnumVal->second, encodingEnumVal->second, templateSpace, outstr );
+				el.singleObject.reset( duoti );
+				elem.anyList.push_back( std::move( el ) );
 			}
 			stack.push_back( std::move(elem) );
 			break;


### PR DESCRIPTION
DISCRIMINATED-UNION-OPTIONS currently does ignore options with out any members.
This makes harder to check where a discriminant value is correct and maps an empty list of members, and when a discriminant value is unexpected.

Proposed change will add an empty list of members for options without any members, making the number of results of DISCRIMINATED-UNION-OPTIONS consistent with the number of values in DISCRIMINATED-UNION-DISCRIMINATOR
